### PR TITLE
Using assertSame to make assertion equals strict

### DIFF
--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -56,9 +56,9 @@ class MessageTest extends TestCase
         $this->assertNotEquals($mess, $copy);
 
         // default value
-        $this->assertEquals('1.1', $mess->getProtocolVersion());
+        $this->assertSame('1.1', $mess->getProtocolVersion());
         // assigned value
-        $this->assertEquals('2.0', $copy->getProtocolVersion());
+        $this->assertSame('2.0', $copy->getProtocolVersion());
     }
 
     /**
@@ -83,8 +83,8 @@ class MessageTest extends TestCase
 
         $this->assertInstanceOf(MessageInterface::class, $copy);
         $this->assertNotEquals($mess, $copy);
-        $this->assertEquals([], $mess->getHeaders());
-        $this->assertEquals(['X-Foo' => ['bar']], $copy->getHeaders());
+        $this->assertSame([], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar']], $copy->getHeaders());
     }
 
     /**
@@ -94,7 +94,7 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('X-Foo', ['bar', 'baz']);
 
-        $this->assertEquals(['X-Foo' => ['bar', 'baz']], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar', 'baz']], $mess->getHeaders());
     }
 
     /**
@@ -106,7 +106,7 @@ class MessageTest extends TestCase
             ->withHeader('X-Foo', ['bar', 'baz'])
             ->withHeader('X-Quux', ['quuux', 'quuuux']);
 
-        $this->assertEquals([
+        $this->assertSame([
             'X-Foo' => ['bar', 'baz'],
             'X-Quux' => ['quuux', 'quuuux'],
         ], $mess->getHeaders());
@@ -119,7 +119,7 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('x-foo', 'bar');
 
-        $this->assertEquals(['X-Foo' => ['bar']], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar']], $mess->getHeaders());
     }
 
     /**
@@ -168,8 +168,8 @@ class MessageTest extends TestCase
 
         $this->assertInstanceOf(MessageInterface::class, $copy);
         $this->assertNotEquals($mess, $copy);
-        $this->assertEquals(['X-Foo' => ['bar']], $mess->getHeaders());
-        $this->assertEquals(['X-Foo' => ['bar', 'baz']], $copy->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar']], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar', 'baz']], $copy->getHeaders());
     }
 
     /**
@@ -181,7 +181,7 @@ class MessageTest extends TestCase
             ->withHeader('X-Foo', ['bar', 'baz'])
             ->withAddedHeader('X-Foo', ['quux', 'quuux']);
 
-        $this->assertEquals(['X-Foo' => ['bar', 'baz', 'quux', 'quuux']], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar', 'baz', 'quux', 'quuux']], $mess->getHeaders());
     }
 
     /**
@@ -195,7 +195,7 @@ class MessageTest extends TestCase
             ->withAddedHeader('X-Foo', 'quuux')
             ->withAddedHeader('X-Baz', 'quuuux');
 
-        $this->assertEquals([
+        $this->assertSame([
             'X-Foo' => ['bar', 'quuux'],
             'X-Baz' => ['quux', 'quuuux'],
         ], $mess->getHeaders());
@@ -210,7 +210,7 @@ class MessageTest extends TestCase
             ->withHeader('x-foo', 'bar')
             ->withAddedHeader('x-foo', 'baz');
 
-        $this->assertEquals(['X-Foo' => ['bar', 'baz']], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar', 'baz']], $mess->getHeaders());
     }
 
     /**
@@ -259,8 +259,8 @@ class MessageTest extends TestCase
 
         $this->assertInstanceOf(MessageInterface::class, $copy);
         $this->assertNotEquals($mess, $copy);
-        $this->assertEquals(['X-Foo' => ['bar']], $mess->getHeaders());
-        $this->assertEquals([], $copy->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar']], $mess->getHeaders());
+        $this->assertSame([], $copy->getHeaders());
     }
 
     /**
@@ -272,7 +272,7 @@ class MessageTest extends TestCase
             ->withHeader('x-foo', 'bar')
             ->withoutHeader('X-Foo');
 
-        $this->assertEquals([], $mess->getHeaders());
+        $this->assertSame([], $mess->getHeaders());
     }
 
     /**
@@ -283,8 +283,8 @@ class MessageTest extends TestCase
         $mess = (new Message)->withHeader('X-Foo', 'bar');
         $copy = $mess->withHeader('X-Foo', 'baz');
 
-        $this->assertEquals(['X-Foo' => ['bar']], $mess->getHeaders());
-        $this->assertEquals(['X-Foo' => ['baz']], $copy->getHeaders());
+        $this->assertSame(['X-Foo' => ['bar']], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['baz']], $copy->getHeaders());
     }
 
     /**
@@ -296,7 +296,7 @@ class MessageTest extends TestCase
             ->withHeader('x-foo', 'bar')
             ->withHeader('X-Foo', 'baz');
 
-        $this->assertEquals(['X-Foo' => ['baz']], $mess->getHeaders());
+        $this->assertSame(['X-Foo' => ['baz']], $mess->getHeaders());
     }
 
     /**
@@ -329,8 +329,8 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('X-Foo', 'bar');
 
-        $this->assertEquals(['bar'], $mess->getHeader('X-Foo'));
-        $this->assertEquals([], $mess->getHeader('X-Bar'));
+        $this->assertSame(['bar'], $mess->getHeader('X-Foo'));
+        $this->assertSame([], $mess->getHeader('X-Bar'));
     }
 
     /**
@@ -340,9 +340,9 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('x-foo', 'bar');
 
-        $this->assertEquals(['bar'], $mess->getHeader('x-foo'));
-        $this->assertEquals(['bar'], $mess->getHeader('X-Foo'));
-        $this->assertEquals(['bar'], $mess->getHeader('X-FOO'));
+        $this->assertSame(['bar'], $mess->getHeader('x-foo'));
+        $this->assertSame(['bar'], $mess->getHeader('X-Foo'));
+        $this->assertSame(['bar'], $mess->getHeader('X-FOO'));
     }
 
     /**
@@ -352,7 +352,7 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('X-Foo', ['bar', 'baz', 'quux']);
 
-        $this->assertEquals(['bar', 'baz', 'quux'], $mess->getHeader('X-Foo'));
+        $this->assertSame(['bar', 'baz', 'quux'], $mess->getHeader('X-Foo'));
     }
 
     /**
@@ -362,8 +362,8 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('X-Foo', 'bar');
 
-        $this->assertEquals('bar', $mess->getHeaderLine('X-Foo'));
-        $this->assertEquals('', $mess->getHeaderLine('X-Bar'));
+        $this->assertSame('bar', $mess->getHeaderLine('X-Foo'));
+        $this->assertSame('', $mess->getHeaderLine('X-Bar'));
     }
 
     /**
@@ -373,9 +373,9 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('x-foo', 'bar');
 
-        $this->assertEquals('bar', $mess->getHeaderLine('x-foo'));
-        $this->assertEquals('bar', $mess->getHeaderLine('X-Foo'));
-        $this->assertEquals('bar', $mess->getHeaderLine('X-FOO'));
+        $this->assertSame('bar', $mess->getHeaderLine('x-foo'));
+        $this->assertSame('bar', $mess->getHeaderLine('X-Foo'));
+        $this->assertSame('bar', $mess->getHeaderLine('X-FOO'));
     }
 
     /**
@@ -385,7 +385,7 @@ class MessageTest extends TestCase
     {
         $mess = (new Message)->withHeader('X-Foo', ['bar', 'baz', 'quux']);
 
-        $this->assertEquals('bar, baz, quux', $mess->getHeaderLine('X-Foo'));
+        $this->assertSame('bar, baz, quux', $mess->getHeaderLine('X-Foo'));
     }
 
     /**
@@ -403,7 +403,7 @@ class MessageTest extends TestCase
         // default value
         $this->assertNotSame($body, $mess->getBody());
         // assigned value
-        $this->assertEquals($body, $copy->getBody());
+        $this->assertSame($body, $copy->getBody());
     }
 
     // Providers...

--- a/tests/RequestFactoryTest.php
+++ b/tests/RequestFactoryTest.php
@@ -41,15 +41,15 @@ class RequestFactoryTest extends TestCase
         $request = (new RequestFactory)->createRequest($method, $uri);
 
         $this->assertInstanceOf(RequestInterface::class, $request);
-        $this->assertEquals($method, $request->getMethod());
-        $this->assertEquals($uri, $request->getUri());
+        $this->assertSame($method, $request->getMethod());
+        $this->assertSame($uri, $request->getUri());
 
         // default body of the request...
         $this->assertInstanceOf(StreamInterface::class, $request->getBody());
         $this->assertTrue($request->getBody()->isSeekable());
         $this->assertTrue($request->getBody()->isWritable());
         $this->assertTrue($request->getBody()->isReadable());
-        $this->assertEquals('php://temp', $request->getBody()->getMetadata('uri'));
+        $this->assertSame('php://temp', $request->getBody()->getMetadata('uri'));
     }
 
     /**
@@ -61,7 +61,7 @@ class RequestFactoryTest extends TestCase
         $request = (new RequestFactory)->createRequest('GET', $uri);
 
         $this->assertInstanceOf(UriInterface::class, $request->getUri());
-        $this->assertEquals($uri, (string) $request->getUri());
+        $this->assertSame($uri, (string) $request->getUri());
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -74,9 +74,9 @@ class RequestTest extends TestCase
         $this->assertNotEquals($mess, $copy);
 
         // default value
-        $this->assertEquals('GET', $mess->getMethod());
+        $this->assertSame('GET', $mess->getMethod());
         // assigned value
-        $this->assertEquals('POST', $copy->getMethod());
+        $this->assertSame('POST', $copy->getMethod());
     }
 
     /**
@@ -86,7 +86,7 @@ class RequestTest extends TestCase
     {
         $mess = (new Request)->withMethod('post');
 
-        $this->assertEquals('POST', $mess->getMethod());
+        $this->assertSame('POST', $mess->getMethod());
     }
 
     /**
@@ -98,7 +98,7 @@ class RequestTest extends TestCase
     {
         $mess = (new Request)->withMethod($method);
 
-        $this->assertEquals($method, $mess->getMethod());
+        $this->assertSame($method, $mess->getMethod());
     }
 
     /**
@@ -126,9 +126,9 @@ class RequestTest extends TestCase
         $this->assertNotEquals($mess, $copy);
 
         // default value
-        $this->assertEquals('/', $mess->getRequestTarget());
+        $this->assertSame('/', $mess->getRequestTarget());
         // assigned value
-        $this->assertEquals('/path?query', $copy->getRequestTarget());
+        $this->assertSame('/path?query', $copy->getRequestTarget());
     }
 
     /**
@@ -140,7 +140,7 @@ class RequestTest extends TestCase
     {
         $mess = (new Request)->withRequestTarget($requestTarget);
 
-        $this->assertEquals($requestTarget, $mess->getRequestTarget());
+        $this->assertSame($requestTarget, $mess->getRequestTarget());
     }
 
     /**
@@ -164,7 +164,7 @@ class RequestTest extends TestCase
         $mess = (new Request)->withUri($uri);
 
         // returns "/" as default path
-        $this->assertEquals('/', $mess->getRequestTarget());
+        $this->assertSame('/', $mess->getRequestTarget());
     }
 
     /**
@@ -176,7 +176,7 @@ class RequestTest extends TestCase
         $mess = (new Request)->withUri($uri);
 
         // returns "/" as default path
-        $this->assertEquals('/', $mess->getRequestTarget());
+        $this->assertSame('/', $mess->getRequestTarget());
     }
 
     /**
@@ -187,7 +187,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('/path');
         $mess = (new Request)->withUri($uri);
 
-        $this->assertEquals('/path', $mess->getRequestTarget());
+        $this->assertSame('/path', $mess->getRequestTarget());
     }
 
     /**
@@ -198,7 +198,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('/path?query');
         $mess = (new Request)->withUri($uri);
 
-        $this->assertEquals('/path?query', $mess->getRequestTarget());
+        $this->assertSame('/path?query', $mess->getRequestTarget());
     }
 
     /**
@@ -209,7 +209,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('/new');
         $mess = (new Request)->withRequestTarget('/primary')->withUri($uri);
 
-        $this->assertEquals('/primary', $mess->getRequestTarget());
+        $this->assertSame('/primary', $mess->getRequestTarget());
     }
 
     /**
@@ -228,7 +228,7 @@ class RequestTest extends TestCase
         // default value
         $this->assertNotSame($uri, $mess->getUri());
         // assigned value
-        $this->assertEquals($uri, $copy->getUri());
+        $this->assertSame($uri, $copy->getUri());
     }
 
     /**
@@ -239,7 +239,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('http://localhost');
         $mess = (new Request)->withUri($uri);
 
-        $this->assertEquals($uri->getHost(), $mess->getHeaderLine('host'));
+        $this->assertSame($uri->getHost(), $mess->getHeaderLine('host'));
     }
 
     /**
@@ -250,7 +250,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('http://localhost:3000');
         $mess = (new Request)->withUri($uri);
 
-        $this->assertEquals($uri->getHost() . ':' . $uri->getPort(), $mess->getHeaderLine('host'));
+        $this->assertSame($uri->getHost() . ':' . $uri->getPort(), $mess->getHeaderLine('host'));
     }
 
     /**
@@ -261,7 +261,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('http://localhost');
         $mess = (new Request)->withHeader('host', 'example.com')->withUri($uri);
 
-        $this->assertEquals($uri->getHost(), $mess->getHeaderLine('host'));
+        $this->assertSame($uri->getHost(), $mess->getHeaderLine('host'));
     }
 
     /**
@@ -272,7 +272,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('http://localhost');
         $mess = (new Request)->withHeader('host', 'example.com')->withUri($uri, true);
 
-        $this->assertEquals('example.com', $mess->getHeaderLine('host'));
+        $this->assertSame('example.com', $mess->getHeaderLine('host'));
     }
 
     /**
@@ -283,7 +283,7 @@ class RequestTest extends TestCase
         $uri = (new UriFactory)->createUri('http://localhost');
         $mess = (new Request)->withUri($uri, true);
 
-        $this->assertEquals($uri->getHost(), $mess->getHeaderLine('host'));
+        $this->assertSame($uri->getHost(), $mess->getHeaderLine('host'));
     }
 
     // Providers...

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -41,15 +41,15 @@ class ResponseFactoryTest extends TestCase
             ->createResponse($statusCode, $reasonPhrase);
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals($statusCode, $response->getStatusCode());
-        $this->assertEquals($reasonPhrase, $response->getReasonPhrase());
+        $this->assertSame($statusCode, $response->getStatusCode());
+        $this->assertSame($reasonPhrase, $response->getReasonPhrase());
 
         // default body of the response...
         $this->assertInstanceOf(StreamInterface::class, $response->getBody());
         $this->assertTrue($response->getBody()->isSeekable());
         $this->assertTrue($response->getBody()->isWritable());
         $this->assertTrue($response->getBody()->isReadable());
-        $this->assertEquals('php://temp', $response->getBody()->getMetadata('uri'));
+        $this->assertSame('php://temp', $response->getBody()->getMetadata('uri'));
     }
 
     /**

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -47,12 +47,12 @@ class ResponseTest extends TestCase
         $this->assertNotEquals($mess, $copy);
 
         // default values
-        $this->assertEquals(200, $mess->getStatusCode());
-        $this->assertEquals(REASON_PHRASES[200], $mess->getReasonPhrase());
+        $this->assertSame(200, $mess->getStatusCode());
+        $this->assertSame(REASON_PHRASES[200], $mess->getReasonPhrase());
 
         // assigned values
-        $this->assertEquals(204, $copy->getStatusCode());
-        $this->assertEquals(REASON_PHRASES[204], $copy->getReasonPhrase());
+        $this->assertSame(204, $copy->getStatusCode());
+        $this->assertSame(REASON_PHRASES[204], $copy->getReasonPhrase());
     }
 
     /**
@@ -64,8 +64,8 @@ class ResponseTest extends TestCase
     {
         $mess = (new Response)->withStatus($statusCode);
 
-        $this->assertEquals($statusCode, $mess->getStatusCode());
-        $this->assertEquals($reasonPhrase, $mess->getReasonPhrase());
+        $this->assertSame($statusCode, $mess->getStatusCode());
+        $this->assertSame($reasonPhrase, $mess->getReasonPhrase());
     }
 
     /**
@@ -87,7 +87,7 @@ class ResponseTest extends TestCase
     {
         $mess = (new Response)->withStatus(599);
 
-        $this->assertEquals('Unknown Status Code', $mess->getReasonPhrase());
+        $this->assertSame('Unknown Status Code', $mess->getReasonPhrase());
     }
 
     /**
@@ -109,7 +109,7 @@ class ResponseTest extends TestCase
     {
         $mess = (new Response)->withStatus(200, 'test');
 
-        $this->assertEquals('test', $mess->getReasonPhrase());
+        $this->assertSame('test', $mess->getReasonPhrase());
     }
 
     // Providers...


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and make these assertions strict.